### PR TITLE
Remove @volkovlabs/components: inline AutosizeCodeEditor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ src/
 │   ├── TextPanel/             # Main panel component
 │   ├── Text/                  # Content renderer
 │   ├── Row/                   # Per-row renderer
+│   ├── AutosizeCodeEditor/    # Monaco editor with autosize and toolbar
 │   ├── CustomEditor/          # Base code editor
 │   ├── ContentPartialsEditor/ # Partials management
 │   └── ResourcesEditor/      # External resources management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+#### Source
+
+- Inlined `@volkovlabs/components` (`AutosizeCodeEditor`, `CodeParameterItem`,
+  `CodeParametersBuilder`) into `src/` to remove Volkov Labs dependency.
+- Added unit tests for `AutosizeCodeEditor` (21 tests) and `Toolbar` (25 tests).
+- Added error handling for clipboard operations in `AutosizeCodeEditor` toolbar.
+
 #### CI/CD
 
 - Added coverage report workflow that posts Jest coverage summary to PRs.
@@ -57,6 +64,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 #### Source
 
+- Wrapped inline `Toolbar` click handlers in `useCallback` hooks.
 - Aligned `eslint.config.mjs` with Grafana scaffolded flat config pattern.
 - Replaced `volkovlabs.io` URLs with Grafana equivalents in provisioning
   dashboards, datasources, and documentation.
@@ -80,6 +88,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 #### Dependencies
 
+- Removed `@volkovlabs/components` dependency (inlined into source).
 - Removed `@volkovlabs/eslint-config` dependency.
 - Removed unused devDependencies: `@types/lodash`, `@babel/preset-typescript`,
   `@babel/register`, `tsconfig-paths`.
@@ -94,8 +103,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 #### Source
 
-- Fixed import grouping and ordering in `CustomEditor.tsx`, `CustomEditor.test.tsx`,
-  `ContentPartialsEditor.test.tsx`, `ResourcesEditor.test.tsx`, and `code-parameters.ts`.
+- Fixed `showMiniMap` prop not syncing to state after initial render in
+  `AutosizeCodeEditor`; removed unnecessary type casts on `setIsShowMiniMap`.
+- Wrapped `onDismiss` in `useCallback` and memoized `displayValue` with
+  `useMemo` in `AutosizeCodeEditor`.
+- Added cleanup for `setTimeout` in modal editor mount to prevent firing
+  after unmount.
+- Removed duplicate height calculation from `onValueChange` (handled by
+  `useEffect`).
+- Fixed import grouping and ordering in `AutosizeCodeEditor.tsx`, `Toolbar.tsx`,
+  `CustomEditor.tsx`, `CustomEditor.test.tsx`, `ContentPartialsEditor.test.tsx`,
+  `ResourcesEditor.test.tsx`, and `code-parameters.ts`.
+- Fixed `@grafana/ui` import line exceeding 120-character print width in
+  `Toolbar.tsx`.
+- Moved inline `css` literals in `Toolbar.tsx` to `AutosizeCodeEditor.styles.ts`.
+- Added missing `@type` and `@param` tags to `Toolbar` Props,
+  `code-parameters-builder.ts` properties, and constructor.
 - Restored `eslint-disable no-console` in `code.ts` after accidental removal.
 - Fixed trailing whitespace in `global.d.ts`, `helper-date.d.ts`,
   `code-parameters.ts`, and `html.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@grafana/schema": "^12.4.2",
         "@grafana/ui": "^12.4.2",
         "@hello-pangea/dnd": "^18.0.1",
-        "@volkovlabs/components": "^4.4.0",
         "dayjs": "^1.11.20",
         "handlebars": "^4.7.9",
         "helper-date": "^1.0.1",
@@ -4831,6 +4830,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4878,6 +4878,7 @@
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -4943,6 +4944,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -5259,7 +5261,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -5592,86 +5594,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@volkovlabs/components": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@volkovlabs/components/-/components-4.6.0.tgz",
-      "integrity": "sha512-tZoXHvAP8oPdKkuqeU4vHzIKoQ/ZhhZNWjbTccyOvP/XYJWe0ls80cJIcRc+kWWBFqZS+nr7aytXPmqq9mAWYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@emotion/css": "^11.11.2",
-        "@grafana/data": "^12.1.0",
-        "@grafana/runtime": "^12.1.0",
-        "@grafana/scenes": "^5.20.2",
-        "@grafana/ui": "^12.1.0",
-        "@volkovlabs/jest-selectors": "^1.5.0",
-        "classnames": "^2.5.1",
-        "rc-slider": "^10.5.0",
-        "rc-tooltip": "^6.2.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@volkovlabs/components/node_modules/@emotion/css": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
-      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2"
-      }
-    },
-    "node_modules/@volkovlabs/components/node_modules/@grafana/scenes": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@grafana/scenes/-/scenes-5.42.0.tgz",
-      "integrity": "sha512-cjFDynL2bOyrhXL8MV3RyBtsgnMpdx78tc5DPXcKYal5uJYlc7Kw26PCRinIxu69uktB8IIvNlm74pqoixzZuA==",
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@floating-ui/react": "^0.26.16",
-        "@leeoniya/ufuzzy": "^1.0.16",
-        "@tanstack/react-virtual": "^3.9.0",
-        "react-grid-layout": "^1.3.4",
-        "react-use": "^17.5.0",
-        "react-virtualized-auto-sizer": "^1.0.24",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@grafana/data": ">=10.4",
-        "@grafana/e2e-selectors": ">=10.4",
-        "@grafana/runtime": ">=10.4",
-        "@grafana/schema": ">=10.4",
-        "@grafana/ui": ">=10.4",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@volkovlabs/components/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@volkovlabs/jest-selectors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@volkovlabs/jest-selectors/-/jest-selectors-1.5.0.tgz",
-      "integrity": "sha512-fe5lzHr1g17KMDbssXS52zPdcGF35U9j3EFDBmUIqjhsf//CN6Uv0zJWBfdhJwwHelpkGWEeI0zCsx1DaIw3MQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@testing-library/react": "^16.0.1"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6162,6 +6084,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -8160,6 +8083,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8246,6 +8170,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -13261,6 +13186,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -15080,6 +15006,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15095,6 +15022,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15105,6 +15033,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15118,6 +15047,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -15350,21 +15280,6 @@
         "quickselect": "^3.0.0"
       }
     },
-    "node_modules/rc-motion": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
-      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc-overflow": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
@@ -15391,79 +15306,6 @@
         "classnames": "^2.2.1",
         "rc-util": "^5.44.1",
         "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-slider": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.6.2.tgz",
-      "integrity": "sha512-FjkoFjyvUQWcBo1F3RgSglky3ar0+qHLM41PlFVYB4Bj3RD8E/Mv7kqMouLFBU+3aFglMzzctAIWRwajEuueSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
-      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.1",
-        "rc-util": "^5.44.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip/node_modules/@rc-component/portal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
-      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip/node_modules/@rc-component/trigger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
-      "integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@rc-component/portal": "^1.1.0",
-        "classnames": "^2.3.2",
-        "rc-motion": "^2.0.0",
-        "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.44.0"
-      },
-      "engines": {
-        "node": ">=8.x"
       },
       "peerDependencies": {
         "react": ">=16.9.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@grafana/schema": "^12.4.2",
     "@grafana/ui": "^12.4.2",
     "@hello-pangea/dnd": "^18.0.1",
-    "@volkovlabs/components": "^4.4.0",
     "dayjs": "^1.11.20",
     "handlebars": "^4.7.9",
     "helper-date": "^1.0.1",

--- a/src/components/AutosizeCodeEditor/AutosizeCodeEditor.styles.ts
+++ b/src/components/AutosizeCodeEditor/AutosizeCodeEditor.styles.ts
@@ -1,0 +1,62 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+/**
+ * Styles
+ */
+export const getStyles = (theme: GrafanaTheme2) => ({
+  toolbar: css`
+    margin: 0 0;
+    border: 1px solid ${theme.colors.border.medium};
+    border-bottom: 0;
+    background: ${theme.colors.background.secondary};
+    padding: ${theme.spacing(0.5)};
+  `,
+  modal: css`
+    width: 80%;
+    height: 80%;
+  `,
+  content: css`
+    padding: ${theme.spacing(1)};
+    height: 100%;
+  `,
+  modalBody: css`
+    height: 100%;
+  `,
+  modalEditor: css`
+    height: 100%;
+    border-radius: 2px;
+    border: 1px solid ${theme.colors.border.medium};
+  `,
+  copyPasteSection: css`
+    margin: ${theme.spacing(0.5)} 0 0 ${theme.spacing(1)};
+  `,
+  copyPasteIcon: css`
+    margin: ${theme.spacing(0)};
+  `,
+  copyPasteText: css`
+    margin: ${theme.spacing(0)};
+    font-size: 12px;
+    color: ${theme.colors.text.secondary};
+    transition: width 0.5s ease;
+  `,
+  text: css`
+    position: absolute;
+    left: -20%;
+    opacity: 0;
+    top: 8px;
+    transition:
+      left 0.5s ease,
+      opacity 0.5s ease;
+  `,
+  textVisible: css`
+    left: 0;
+    opacity: 1;
+  `,
+  copyPasteTextActive: css`
+    width: 45px;
+  `,
+  copyPasteTextIdle: css`
+    width: 10px;
+  `,
+});

--- a/src/components/AutosizeCodeEditor/AutosizeCodeEditor.test.tsx
+++ b/src/components/AutosizeCodeEditor/AutosizeCodeEditor.test.tsx
@@ -1,0 +1,297 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TEST_IDS } from '../../constants';
+
+import { AutosizeCodeEditor } from './AutosizeCodeEditor';
+
+/**
+ * IntersectionObserver polyfill for PageToolbar
+ */
+beforeAll(() => {
+  global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
+
+/**
+ * Mock @grafana/ui
+ */
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: jest.fn().mockImplementation((props) => (
+    <textarea
+      data-testid="mock-code-editor"
+      value={props.value}
+      onChange={(e) => props.onChange?.(e.target.value)}
+      onBlur={(e) => props.onBlur?.(e.target.value)}
+    />
+  )),
+  Modal: jest.fn().mockImplementation(({ children, isOpen }) =>
+    isOpen ? <div data-testid="mock-modal">{children}</div> : null
+  ),
+}));
+
+/**
+ * Mock clipboard API
+ */
+const mockWriteText = jest.fn().mockResolvedValue(undefined);
+const mockReadText = jest.fn().mockResolvedValue('pasted text');
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+    readText: mockReadText,
+  },
+});
+
+/**
+ * Mock timers
+ */
+jest.useFakeTimers();
+
+/**
+ * Get Component
+ */
+const getComponent = (props: Partial<React.ComponentProps<typeof AutosizeCodeEditor>> = {}) => {
+  return <AutosizeCodeEditor value="" language="javascript" showLineNumbers={true} {...props} />;
+};
+
+/**
+ * Autosize Code Editor
+ */
+describe('AutosizeCodeEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Rendering
+   */
+  describe('Rendering', () => {
+    it('Should render toolbar with expand button', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-open'))).toBeInTheDocument();
+    });
+
+    it('Should render copy and paste buttons', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.copyButton)).toBeInTheDocument();
+      expect(screen.getByTestId(TEST_IDS.codeEditor.pasteButton)).toBeInTheDocument();
+    });
+
+    it('Should render wrap button', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.wrapButton)).toBeInTheDocument();
+    });
+
+    it('Should render code editor', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId('mock-code-editor')).toBeInTheDocument();
+    });
+
+    it('Should show mini map button when value exceeds 100 characters', () => {
+      render(getComponent({ value: 'a'.repeat(101) }));
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.miniMapButton)).toBeInTheDocument();
+    });
+
+    it('Should not show mini map button when value is short', () => {
+      render(getComponent({ value: 'short' }));
+
+      expect(screen.queryByTestId(TEST_IDS.codeEditor.miniMapButton)).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Modal
+   */
+  describe('Modal', () => {
+    it('Should open modal when expand button is clicked', async () => {
+      render(getComponent());
+
+      expect(screen.queryByTestId(TEST_IDS.codeEditor.modal)).not.toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-open')));
+      });
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.modal)).toBeInTheDocument();
+    });
+
+    it('Should show collapse button inside modal', async () => {
+      render(getComponent());
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-open')));
+      });
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-close'))).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Clipboard
+   */
+  describe('Clipboard', () => {
+    it('Should copy editor value to clipboard', async () => {
+      render(getComponent({ value: 'test code' }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith('test code');
+    });
+
+    it('Should show copied feedback message', async () => {
+      render(getComponent({ value: 'test code' }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+    });
+
+    it('Should clear feedback message after 1 second', async () => {
+      render(getComponent({ value: 'test code' }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+    });
+
+    it('Should show failure message when copy fails', async () => {
+      mockWriteText.mockRejectedValueOnce(new Error('Permission denied'));
+
+      render(getComponent({ value: 'test code' }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(screen.getByText('Copy failed')).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Word Wrap
+   */
+  describe('Word Wrap', () => {
+    it('Should toggle word wrap on click', async () => {
+      const { rerender } = render(getComponent({ monacoOptions: { wordWrap: 'off' } }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.wrapButton));
+      });
+
+      /**
+       * Re-render to verify state change propagated
+       */
+      rerender(getComponent({ monacoOptions: { wordWrap: 'off' } }));
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.wrapButton)).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Escaping
+   */
+  describe('Escaping', () => {
+    it('Should unescape value for display when isEscaping is true', () => {
+      render(getComponent({ value: 'line1\\nline2', isEscaping: true }));
+
+      const editor = screen.getByTestId('mock-code-editor') as HTMLTextAreaElement;
+      expect(editor.value).toBe('line1\nline2');
+    });
+
+    it('Should pass value as-is when isEscaping is false', () => {
+      render(getComponent({ value: 'line1\nline2', isEscaping: false }));
+
+      const editor = screen.getByTestId('mock-code-editor') as HTMLTextAreaElement;
+      expect(editor.value).toBe('line1\nline2');
+    });
+  });
+
+  /**
+   * Callbacks
+   */
+  describe('Callbacks', () => {
+    it('Should call onChange when editor value changes', async () => {
+      const onChange = jest.fn();
+      render(getComponent({ onChange }));
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId('mock-code-editor'), { target: { value: 'new value' } });
+      });
+
+      expect(onChange).toHaveBeenCalledWith('new value');
+    });
+
+    it('Should escape newlines in onChange when isEscaping is true', async () => {
+      const onChange = jest.fn();
+      render(getComponent({ onChange, isEscaping: true }));
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId('mock-code-editor'), { target: { value: 'line1\nline2' } });
+      });
+
+      expect(onChange).toHaveBeenCalledWith('line1\\nline2');
+    });
+
+    it('Should call onBlur when editor loses focus', async () => {
+      const onBlur = jest.fn();
+      render(getComponent({ onBlur }));
+
+      await act(async () => {
+        fireEvent.blur(screen.getByTestId('mock-code-editor'));
+      });
+
+      expect(onBlur).toHaveBeenCalled();
+    });
+
+    it('Should escape newlines in onBlur when isEscaping is true', async () => {
+      const onBlur = jest.fn();
+      render(getComponent({ onBlur, isEscaping: true, value: 'line1\\nline2' }));
+
+      await act(async () => {
+        fireEvent.blur(screen.getByTestId('mock-code-editor'));
+      });
+
+      expect(onBlur).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Height Calculation
+   */
+  describe('Height Calculation', () => {
+    it('Should render with default min height for empty content', () => {
+      render(getComponent({ value: '' }));
+
+      expect(screen.getByTestId('mock-code-editor')).toBeInTheDocument();
+    });
+
+    it('Should render with content-based height for multi-line content', () => {
+      const multiLine = Array.from({ length: 20 }, (_, i) => `line ${i}`).join('\n');
+      render(getComponent({ value: multiLine }));
+
+      expect(screen.getByTestId('mock-code-editor')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/AutosizeCodeEditor/AutosizeCodeEditor.tsx
+++ b/src/components/AutosizeCodeEditor/AutosizeCodeEditor.tsx
@@ -1,0 +1,267 @@
+import { CodeEditor, CodeEditorMonacoOptions, Modal, useStyles2 } from '@grafana/ui';
+import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { TEST_IDS } from '../../constants';
+
+import { getStyles } from './AutosizeCodeEditor.styles';
+import { Toolbar } from './Toolbar';
+
+/**
+ * Line height in pixels
+ */
+const LINE_HEIGHT = 18;
+
+/**
+ * Default min/max heights
+ */
+const DEFAULT_MIN_HEIGHT = 200;
+const DEFAULT_MAX_HEIGHT = 1000;
+
+/**
+ * Calculate editor height based on content
+ */
+const calculateHeight = (value: string, minHeight?: number, maxHeight?: number): number => {
+  const contentHeight = value.split('\n').length * LINE_HEIGHT;
+  const min = minHeight || DEFAULT_MIN_HEIGHT;
+  const max = maxHeight || DEFAULT_MAX_HEIGHT;
+
+  if (contentHeight < min) {
+    return min;
+  }
+  if (contentHeight > max) {
+    return max;
+  }
+  return contentHeight;
+};
+
+/**
+ * Properties
+ */
+type Props = React.ComponentProps<typeof CodeEditor> & {
+  /**
+   * Min height
+   *
+   * @type {number}
+   */
+  minHeight?: number;
+
+  /**
+   * Max height
+   *
+   * @type {number}
+   */
+  maxHeight?: number;
+
+  /**
+   * Should escape value
+   *
+   * @type {boolean}
+   */
+  isEscaping?: boolean;
+};
+
+/**
+ * Autosize Code Editor
+ */
+export const AutosizeCodeEditor: React.FC<Props> = ({
+  value,
+  onChange,
+  onBlur,
+  minHeight,
+  maxHeight,
+  height,
+  onEditorDidMount,
+  monacoOptions,
+  showMiniMap,
+  isEscaping = false,
+  ...rest
+}) => {
+  /**
+   * Styles
+   */
+  const styles = useStyles2(getStyles);
+
+  /**
+   * State
+   */
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isShowMiniMap, setIsShowMiniMap] = useState<boolean>(showMiniMap ?? false);
+  const [currentMonacoOptions, setCurrentMonacoOptions] = useState<CodeEditorMonacoOptions | undefined>(monacoOptions);
+  const [inlineEditor, setInlineEditor] = useState<monacoType.editor.IStandaloneCodeEditor | null>(null);
+  const [modalEditor, setModalEditor] = useState<monacoType.editor.IStandaloneCodeEditor | null>(null);
+  const [editorHeight, setEditorHeight] = useState(calculateHeight(value, minHeight, maxHeight));
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * Set end-of-line to LF if escaping
+   */
+  const setEol = useCallback(
+    (editor: monacoType.editor.IStandaloneCodeEditor, monaco: typeof monacoType) => {
+      if (isEscaping) {
+        const model = editor.getModel();
+        model?.setEOL(monaco.editor.EndOfLineSequence.LF);
+      }
+    },
+    [isEscaping]
+  );
+
+  /**
+   * Mount handler for inline editor
+   */
+  const onInlineEditorMount = useCallback(
+    (editor: monacoType.editor.IStandaloneCodeEditor, monaco: typeof monacoType) => {
+      setEol(editor, monaco);
+      setInlineEditor(editor);
+      onEditorDidMount?.(editor, monaco);
+    },
+    [setEol, onEditorDidMount]
+  );
+
+  /**
+   * Mount handler for modal editor
+   */
+  const onModalEditorMount = useCallback(
+    (editor: monacoType.editor.IStandaloneCodeEditor, monaco: typeof monacoType) => {
+      setEol(editor, monaco);
+      setModalEditor(editor);
+
+      if (inlineEditor) {
+        const position = inlineEditor.getPosition();
+        if (position) {
+          editor.setPosition({
+            lineNumber: position.lineNumber,
+            column: position.column,
+          });
+          editor.focus();
+          revealTimerRef.current = setTimeout(() => {
+            editor.revealLineInCenter(position.lineNumber);
+            revealTimerRef.current = null;
+          }, 0);
+        }
+      }
+
+      onEditorDidMount?.(editor, monaco);
+    },
+    [setEol, inlineEditor, onEditorDidMount]
+  );
+
+  /**
+   * Change handler
+   */
+  const onValueChange = useCallback(
+    (newValue: string) => {
+      const result = isEscaping ? newValue.replaceAll('\n', '\\n') : newValue;
+      onChange?.(result);
+    },
+    [onChange, isEscaping]
+  );
+
+  /**
+   * Blur handler
+   */
+  const onValueBlur = useCallback(
+    (newValue: string) => {
+      const result = isEscaping ? newValue.replaceAll('\n', '\\n') : newValue;
+      onBlur?.(result);
+    },
+    [onBlur, isEscaping]
+  );
+
+  /**
+   * Clean up reveal timer on unmount
+   */
+  useEffect(() => {
+    return () => {
+      if (revealTimerRef.current) {
+        clearTimeout(revealTimerRef.current);
+      }
+    };
+  }, []);
+
+  /**
+   * Sync mini map visibility with prop changes
+   */
+  useEffect(() => {
+    if (showMiniMap !== undefined) {
+      setIsShowMiniMap(showMiniMap);
+    }
+  }, [showMiniMap]);
+
+  /**
+   * Update height on value change
+   */
+  useEffect(() => {
+    setEditorHeight(calculateHeight(value, minHeight, maxHeight));
+  }, [value, minHeight, maxHeight]);
+
+  /**
+   * Dismiss modal handler
+   */
+  const onDismissModal = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+
+  /**
+   * Display value
+   */
+  const displayValue = useMemo(() => (isEscaping ? value.replaceAll('\\n', '\n') : value), [value, isEscaping]);
+
+  return (
+    <>
+      <Toolbar
+        editorValue={value}
+        setIsOpen={setIsModalOpen}
+        monacoEditor={inlineEditor}
+        isShowMiniMap={isShowMiniMap}
+        setIsShowMiniMap={setIsShowMiniMap}
+        currentMonacoOptions={currentMonacoOptions}
+        setCurrentMonacoOptions={setCurrentMonacoOptions}
+        readOnly={rest.readOnly}
+      />
+      <CodeEditor
+        value={displayValue}
+        showMiniMap={isShowMiniMap}
+        height={height ?? editorHeight}
+        monacoOptions={currentMonacoOptions}
+        onEditorDidMount={onInlineEditorMount}
+        onChange={onValueChange}
+        onBlur={onValueBlur}
+        {...rest}
+      />
+      <Modal
+        title="Code editor"
+        isOpen={isModalOpen}
+        onDismiss={onDismissModal}
+        className={styles.modal}
+        contentClassName={styles.modalBody}
+        closeOnEscape={true}
+        trapFocus={true}
+      >
+        <div className={styles.content} data-testid={TEST_IDS.codeEditor.modal}>
+          <Toolbar
+            isModal={true}
+            editorValue={value}
+            setIsOpen={setIsModalOpen}
+            isShowMiniMap={isShowMiniMap}
+            monacoEditor={modalEditor}
+            setIsShowMiniMap={setIsShowMiniMap}
+            currentMonacoOptions={currentMonacoOptions}
+            setCurrentMonacoOptions={setCurrentMonacoOptions}
+            readOnly={rest.readOnly}
+          />
+          <CodeEditor
+            value={displayValue}
+            showMiniMap={isShowMiniMap}
+            containerStyles={styles.modalEditor}
+            monacoOptions={currentMonacoOptions}
+            onEditorDidMount={onModalEditorMount}
+            onChange={onValueChange}
+            onBlur={onValueBlur}
+            {...rest}
+          />
+        </div>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/AutosizeCodeEditor/Toolbar.test.tsx
+++ b/src/components/AutosizeCodeEditor/Toolbar.test.tsx
@@ -1,0 +1,378 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TEST_IDS } from '../../constants';
+
+import { Toolbar } from './Toolbar';
+
+/**
+ * IntersectionObserver polyfill for PageToolbar
+ */
+beforeAll(() => {
+  global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
+
+/**
+ * Mock clipboard API
+ */
+const mockWriteText = jest.fn().mockResolvedValue(undefined);
+const mockReadText = jest.fn().mockResolvedValue('pasted text');
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+    readText: mockReadText,
+  },
+});
+
+/**
+ * Mock timers
+ */
+jest.useFakeTimers();
+
+/**
+ * Mock Monaco editor
+ */
+const createMockEditor = () => ({
+  getSelection: jest.fn().mockReturnValue({
+    startLineNumber: 1,
+    startColumn: 1,
+    endLineNumber: 1,
+    endColumn: 1,
+  }),
+  executeEdits: jest.fn(),
+  focus: jest.fn(),
+});
+
+/**
+ * Default props
+ */
+const defaultProps: React.ComponentProps<typeof Toolbar> = {
+  monacoEditor: null,
+  setIsOpen: jest.fn(),
+  editorValue: 'test code',
+  setCurrentMonacoOptions: jest.fn(),
+  currentMonacoOptions: undefined,
+  isShowMiniMap: false,
+  setIsShowMiniMap: jest.fn(),
+};
+
+/**
+ * Get Component
+ */
+const getComponent = (props: Partial<React.ComponentProps<typeof Toolbar>> = {}) => {
+  return <Toolbar {...defaultProps} {...props} />;
+};
+
+/**
+ * Toolbar
+ */
+describe('Toolbar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Rendering
+   */
+  describe('Rendering', () => {
+    it('Should render expand button', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-open'))).toBeInTheDocument();
+    });
+
+    it('Should render collapse button when in modal mode', () => {
+      render(getComponent({ isModal: true }));
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-close'))).toBeInTheDocument();
+    });
+
+    it('Should render copy button', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.copyButton)).toBeInTheDocument();
+    });
+
+    it('Should render paste button', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.pasteButton)).toBeInTheDocument();
+    });
+
+    it('Should render wrap button', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.wrapButton)).toBeInTheDocument();
+    });
+
+    it('Should render mini map button when value exceeds 100 characters', () => {
+      render(getComponent({ editorValue: 'a'.repeat(101) }));
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.miniMapButton)).toBeInTheDocument();
+    });
+
+    it('Should not render mini map button when value is short', () => {
+      render(getComponent({ editorValue: 'short' }));
+
+      expect(screen.queryByTestId(TEST_IDS.codeEditor.miniMapButton)).not.toBeInTheDocument();
+    });
+
+    it('Should render copy paste text area', () => {
+      render(getComponent());
+
+      expect(screen.getByTestId(TEST_IDS.codeEditor.copyPasteText)).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Modal Toggle
+   */
+  describe('Modal Toggle', () => {
+    it('Should call setIsOpen with true when expand is clicked', async () => {
+      const setIsOpen = jest.fn();
+      render(getComponent({ setIsOpen }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-open')));
+      });
+
+      expect(setIsOpen).toHaveBeenCalledWith(true);
+    });
+
+    it('Should call setIsOpen with false when collapse is clicked in modal', async () => {
+      const setIsOpen = jest.fn();
+      render(getComponent({ setIsOpen, isModal: true }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.modalButton('modal-close')));
+      });
+
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+  });
+
+  /**
+   * Copy
+   */
+  describe('Copy', () => {
+    it('Should copy editor value to clipboard', async () => {
+      render(getComponent({ editorValue: 'hello world' }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith('hello world');
+    });
+
+    it('Should show Copied! feedback on success', async () => {
+      render(getComponent());
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+    });
+
+    it('Should show Copy failed feedback on error', async () => {
+      mockWriteText.mockRejectedValueOnce(new Error('Permission denied'));
+
+      render(getComponent());
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(screen.getByText('Copy failed')).toBeInTheDocument();
+    });
+
+    it('Should clear feedback message after 1 second', async () => {
+      render(getComponent());
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.copyButton));
+      });
+
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Paste
+   */
+  describe('Paste', () => {
+    it('Should paste clipboard text into editor', async () => {
+      const mockEditor = createMockEditor();
+      render(getComponent({ monacoEditor: mockEditor as never }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.pasteButton));
+      });
+
+      expect(mockReadText).toHaveBeenCalled();
+      expect(mockEditor.executeEdits).toHaveBeenCalledWith('clipboard', [
+        {
+          range: {
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 1,
+          },
+          text: 'pasted text',
+          forceMoveMarkers: false,
+        },
+      ]);
+      expect(mockEditor.focus).toHaveBeenCalled();
+    });
+
+    it('Should show Pasted! feedback on success', async () => {
+      const mockEditor = createMockEditor();
+      render(getComponent({ monacoEditor: mockEditor as never }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.pasteButton));
+      });
+
+      expect(screen.getByText('Pasted!')).toBeInTheDocument();
+    });
+
+    it('Should show Paste failed feedback on error', async () => {
+      mockReadText.mockRejectedValueOnce(new Error('Permission denied'));
+      const mockEditor = createMockEditor();
+      render(getComponent({ monacoEditor: mockEditor as never }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.pasteButton));
+      });
+
+      expect(screen.getByText('Paste failed')).toBeInTheDocument();
+    });
+
+    it('Should not paste when no editor instance', async () => {
+      render(getComponent({ monacoEditor: null }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.pasteButton));
+      });
+
+      expect(mockReadText).not.toHaveBeenCalled();
+    });
+
+    it('Should use editor selection for paste range', async () => {
+      const mockEditor = createMockEditor();
+      mockEditor.getSelection.mockReturnValue({
+        startLineNumber: 3,
+        startColumn: 5,
+        endLineNumber: 3,
+        endColumn: 10,
+      });
+      render(getComponent({ monacoEditor: mockEditor as never }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.pasteButton));
+      });
+
+      expect(mockEditor.executeEdits).toHaveBeenCalledWith('clipboard', [
+        {
+          range: {
+            startLineNumber: 3,
+            startColumn: 5,
+            endLineNumber: 3,
+            endColumn: 10,
+          },
+          text: 'pasted text',
+          forceMoveMarkers: false,
+        },
+      ]);
+    });
+
+    it('Should be disabled when readOnly is true', () => {
+      render(getComponent({ readOnly: true }));
+
+      const pasteButton = screen.getByTestId(TEST_IDS.codeEditor.pasteButton);
+      expect(pasteButton).toBeDisabled();
+    });
+  });
+
+  /**
+   * Word Wrap
+   */
+  describe('Word Wrap', () => {
+    it('Should toggle word wrap from off to on', async () => {
+      const setCurrentMonacoOptions = jest.fn();
+      render(getComponent({ setCurrentMonacoOptions, currentMonacoOptions: { wordWrap: 'off' } }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.wrapButton));
+      });
+
+      expect(setCurrentMonacoOptions).toHaveBeenCalledWith({ wordWrap: 'on' });
+    });
+
+    it('Should toggle word wrap from on to off', async () => {
+      const setCurrentMonacoOptions = jest.fn();
+      render(getComponent({ setCurrentMonacoOptions, currentMonacoOptions: { wordWrap: 'on' } }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.wrapButton));
+      });
+
+      expect(setCurrentMonacoOptions).toHaveBeenCalledWith({ wordWrap: 'off' });
+    });
+
+    it('Should enable word wrap when options are undefined', async () => {
+      const setCurrentMonacoOptions = jest.fn();
+      render(getComponent({ setCurrentMonacoOptions, currentMonacoOptions: undefined }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.wrapButton));
+      });
+
+      expect(setCurrentMonacoOptions).toHaveBeenCalledWith({ wordWrap: 'on' });
+    });
+  });
+
+  /**
+   * Mini Map
+   */
+  describe('Mini Map', () => {
+    it('Should call setIsShowMiniMap with toggle function', async () => {
+      const setIsShowMiniMap = jest.fn();
+      render(getComponent({ editorValue: 'a'.repeat(101), setIsShowMiniMap }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.miniMapButton));
+      });
+
+      expect(setIsShowMiniMap).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('Should toggle mini map from false to true', async () => {
+      const setIsShowMiniMap = jest.fn();
+      render(getComponent({ editorValue: 'a'.repeat(101), setIsShowMiniMap, isShowMiniMap: false }));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId(TEST_IDS.codeEditor.miniMapButton));
+      });
+
+      /**
+       * Verify the toggle function returns the opposite value
+       */
+      const toggleFn = setIsShowMiniMap.mock.calls[0][0];
+      expect(toggleFn(false)).toBe(true);
+      expect(toggleFn(true)).toBe(false);
+    });
+  });
+});

--- a/src/components/AutosizeCodeEditor/Toolbar.tsx
+++ b/src/components/AutosizeCodeEditor/Toolbar.tsx
@@ -1,0 +1,251 @@
+import { cx } from '@emotion/css';
+import {
+  CodeEditorMonacoOptions,
+  InlineField,
+  InlineFieldRow,
+  PageToolbar,
+  ToolbarButton,
+  useStyles2,
+} from '@grafana/ui';
+import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { TEST_IDS } from '../../constants';
+
+import { getStyles } from './AutosizeCodeEditor.styles';
+
+/**
+ * Properties
+ */
+interface Props {
+  /**
+   * Monaco editor instance
+   *
+   * @type {monacoType.editor.IStandaloneCodeEditor | null}
+   */
+  monacoEditor: monacoType.editor.IStandaloneCodeEditor | null;
+
+  /**
+   * Set modal open state
+   *
+   * @type {(isOpen: boolean) => void}
+   */
+  setIsOpen: (isOpen: boolean) => void;
+
+  /**
+   * Current editor value
+   *
+   * @type {string}
+   */
+  editorValue: string;
+
+  /**
+   * Whether this toolbar is inside the modal
+   *
+   * @type {boolean}
+   */
+  isModal?: boolean;
+
+  /**
+   * Set monaco options
+   *
+   * @type {(options: CodeEditorMonacoOptions) => void}
+   */
+  setCurrentMonacoOptions: (options: CodeEditorMonacoOptions) => void;
+
+  /**
+   * Current monaco options
+   *
+   * @type {CodeEditorMonacoOptions | undefined}
+   */
+  currentMonacoOptions: CodeEditorMonacoOptions | undefined;
+
+  /**
+   * Whether mini map is shown
+   *
+   * @type {boolean | undefined}
+   */
+  isShowMiniMap: boolean | undefined;
+
+  /**
+   * Set mini map visibility
+   *
+   * @type {(show: boolean | ((prev: boolean) => boolean)) => void}
+   */
+  setIsShowMiniMap: (show: boolean | ((prev: boolean) => boolean)) => void;
+
+  /**
+   * Whether editor is read-only
+   *
+   * @type {boolean}
+   */
+  readOnly?: boolean;
+}
+
+/**
+ * Toolbar
+ */
+export const Toolbar: React.FC<Props> = ({
+  monacoEditor,
+  setIsOpen,
+  editorValue,
+  isModal = false,
+  setCurrentMonacoOptions,
+  currentMonacoOptions,
+  isShowMiniMap,
+  setIsShowMiniMap,
+  readOnly,
+}) => {
+  /**
+   * Styles
+   */
+  const styles = useStyles2(getStyles);
+
+  /**
+   * Copy/Paste feedback message
+   */
+  const [feedbackMessage, setFeedbackMessage] = useState('');
+
+  /**
+   * Clear feedback message after 1 second
+   */
+  useEffect(() => {
+    if (feedbackMessage) {
+      const timer = setTimeout(() => {
+        setFeedbackMessage('');
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+    return;
+  }, [feedbackMessage]);
+
+  /**
+   * Toggle modal
+   */
+  const onToggleModal = useCallback(() => {
+    setIsOpen(!isModal);
+  }, [isModal, setIsOpen]);
+
+  /**
+   * Copy code to clipboard
+   */
+  const onCopy = useCallback(() => {
+    navigator.clipboard
+      .writeText(editorValue)
+      .then(() => {
+        setFeedbackMessage('Copied!');
+      })
+      .catch(() => {
+        setFeedbackMessage('Copy failed');
+      });
+  }, [editorValue]);
+
+  /**
+   * Paste code from clipboard
+   */
+  const onPaste = useCallback(async () => {
+    if (monacoEditor) {
+      try {
+        const selection = monacoEditor.getSelection();
+        const clipboardText = await navigator.clipboard.readText();
+        const range = {
+          startLineNumber: selection?.startLineNumber || 1,
+          startColumn: selection?.startColumn || 1,
+          endLineNumber: selection?.endLineNumber || 1,
+          endColumn: selection?.endColumn || 1,
+        };
+        monacoEditor.executeEdits('clipboard', [
+          {
+            range,
+            text: clipboardText,
+            forceMoveMarkers: false,
+          },
+        ]);
+        monacoEditor.focus();
+        setFeedbackMessage('Pasted!');
+      } catch {
+        setFeedbackMessage('Paste failed');
+      }
+    }
+  }, [monacoEditor]);
+
+  /**
+   * Toggle word wrap
+   */
+  const onToggleWrap = useCallback(() => {
+    const wordWrap = currentMonacoOptions?.wordWrap === 'on' ? 'off' : 'on';
+    setCurrentMonacoOptions({ ...currentMonacoOptions, wordWrap });
+  }, [currentMonacoOptions, setCurrentMonacoOptions]);
+
+  /**
+   * Toggle mini map
+   */
+  const onToggleMiniMap = useCallback(() => {
+    setIsShowMiniMap((prev: boolean) => !prev);
+  }, [setIsShowMiniMap]);
+
+  return (
+    <PageToolbar
+      buttonOverflowAlignment="right"
+      className={styles.toolbar}
+      forceShowLeftItems={true}
+      leftItems={[
+        <ToolbarButton
+          key="code-editor-button-modal"
+          tooltip={isModal ? 'Collapse code editor' : 'Expand code editor'}
+          icon={isModal ? 'compress-arrows' : 'expand-arrows-alt'}
+          iconSize="lg"
+          onClick={onToggleModal}
+          data-testid={TEST_IDS.codeEditor.modalButton(isModal ? 'modal-close' : 'modal-open')}
+        />,
+      ]}
+    >
+      <InlineFieldRow className={styles.copyPasteSection}>
+        <ToolbarButton
+          className={styles.copyPasteIcon}
+          tooltip="Copy code"
+          icon="file-blank"
+          iconSize="lg"
+          onClick={onCopy}
+          data-testid={TEST_IDS.codeEditor.copyButton}
+        />
+        <ToolbarButton
+          disabled={readOnly}
+          className={styles.copyPasteIcon}
+          tooltip={readOnly ? 'Cannot edit in read-only mode' : 'Paste code'}
+          icon="file-alt"
+          iconSize="lg"
+          onClick={onPaste}
+          data-testid={TEST_IDS.codeEditor.pasteButton}
+        />
+        <InlineField
+          className={cx(
+            styles.copyPasteText,
+            feedbackMessage ? styles.copyPasteTextActive : styles.copyPasteTextIdle
+          )}
+          data-testid={TEST_IDS.codeEditor.copyPasteText}
+        >
+          <div className={cx(styles.text, feedbackMessage ? styles.textVisible : '')}>{feedbackMessage}</div>
+        </InlineField>
+      </InlineFieldRow>
+      <ToolbarButton
+        tooltip="Wrap code on new lines"
+        icon="wrap-text"
+        iconSize="lg"
+        variant={currentMonacoOptions?.wordWrap === 'on' ? 'active' : 'default'}
+        onClick={onToggleWrap}
+        data-testid={TEST_IDS.codeEditor.wrapButton}
+      />
+      {editorValue && editorValue.length > 100 && (
+        <ToolbarButton
+          tooltip={isShowMiniMap ? 'Hide mini map' : 'Show mini map'}
+          icon="gf-movepane-right"
+          iconSize="lg"
+          variant={isShowMiniMap ? 'active' : 'default'}
+          onClick={onToggleMiniMap}
+          data-testid={TEST_IDS.codeEditor.miniMapButton}
+        />
+      )}
+    </PageToolbar>
+  );
+};

--- a/src/components/AutosizeCodeEditor/index.ts
+++ b/src/components/AutosizeCodeEditor/index.ts
@@ -1,0 +1,1 @@
+export { AutosizeCodeEditor } from './AutosizeCodeEditor';

--- a/src/components/CustomEditor/CustomEditor.test.tsx
+++ b/src/components/CustomEditor/CustomEditor.test.tsx
@@ -1,6 +1,5 @@
 import { getTemplateSrv } from '@grafana/runtime';
 import { CodeEditorSuggestionItemKind } from '@grafana/ui';
-import { AutosizeCodeEditor } from '@volkovlabs/components';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -11,7 +10,9 @@ import {
   HELPERS_EDITOR_SUGGESTIONS,
   TEST_IDS,
 } from '../../constants';
-import { CustomEditor, HelpersEditor, StylesEditor, TextEditor, AfterRenderEditor } from './CustomEditor';
+
+import { AutosizeCodeEditor } from '../AutosizeCodeEditor';
+import { AfterRenderEditor, CustomEditor, HelpersEditor, StylesEditor, TextEditor } from './CustomEditor';
 
 /**
  * Mock @grafana/ui
@@ -22,10 +23,10 @@ jest.mock('@grafana/ui', () => ({
 }));
 
 /**
- * Mock @volkovlabs/components
+ * Mock AutosizeCodeEditor
  */
-jest.mock('@volkovlabs/components', () => ({
-  ...jest.requireActual('@volkovlabs/components'),
+jest.mock('../AutosizeCodeEditor', () => ({
+  ...jest.requireActual('../AutosizeCodeEditor'),
   AutosizeCodeEditor: jest.fn().mockImplementation(() => null),
 }));
 

--- a/src/components/CustomEditor/CustomEditor.tsx
+++ b/src/components/CustomEditor/CustomEditor.tsx
@@ -6,10 +6,6 @@ import {
   CodeEditorSuggestionItemKind,
   useTheme2,
 } from '@grafana/ui';
-import { AutosizeCodeEditor } from '@volkovlabs/components';
-/**
- * Monaco
- */
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import React, { useCallback, useMemo } from 'react';
 
@@ -21,6 +17,8 @@ import {
   HELPERS_EDITOR_SUGGESTIONS,
   TEST_IDS,
 } from '../../constants';
+
+import { AutosizeCodeEditor } from '../AutosizeCodeEditor';
 
 /**
  * Properties

--- a/src/constants/tests.ts
+++ b/src/constants/tests.ts
@@ -23,6 +23,15 @@ export const TEST_IDS = {
     newItem: 'data-testid resources-editor new-item',
     newItemName: 'data-testid resources-editor new-item-name',
   },
+  codeEditor: {
+    copyButton: 'data-testid code-editor copy-button',
+    copyPasteText: 'data-testid code-editor copy-paste-text',
+    modal: 'data-testid code-editor modal-window',
+    miniMapButton: 'data-testid code-editor mini-map-button',
+    modalButton: (action: string) => `data-testid code-editor modal-button-${action}`,
+    pasteButton: 'data-testid code-editor paste-button',
+    wrapButton: 'data-testid code-editor wrap-button',
+  },
   partialsEditor: {
     buttonAddNew: 'data-testid partials-editor button-add-new',
     buttonRemove: 'data-testid partials-editor button-remove',

--- a/src/utils/code-parameters-builder.ts
+++ b/src/utils/code-parameters-builder.ts
@@ -1,0 +1,105 @@
+import { CodeEditorSuggestionItem, CodeEditorSuggestionItemKind } from '@grafana/ui';
+
+/**
+ * Code Parameter Group
+ */
+export interface CodeParameterGroup {
+  /**
+   * Detail
+   *
+   * @type {string}
+   */
+  detail: string;
+
+  /**
+   * Items
+   *
+   * @type {Record<string, CodeParameterGroup | CodeParameterItem>}
+   */
+  items: Record<string, CodeParameterGroup | CodeParameterItem>;
+}
+
+/**
+ * Code Parameter Item
+ */
+export class CodeParameterItem<TValue = unknown> {
+  /**
+   * Specify for type validation
+   *
+   * @type {TValue}
+   */
+  value: TValue = {} as TValue;
+
+  /**
+   * @param detail - Description of the parameter
+   * @param kind - Suggestion item kind
+   */
+  constructor(
+    public detail: string,
+    public kind: CodeEditorSuggestionItemKind = CodeEditorSuggestionItemKind.Property
+  ) {}
+}
+
+/**
+ * Convert group to payload object
+ */
+export type PayloadForGroup<TGroup extends CodeParameterGroup> = {
+  [Key in keyof TGroup['items']]: TGroup['items'][Key] extends CodeParameterGroup
+    ? PayloadForGroup<TGroup['items'][Key]>
+    : TGroup['items'][Key] extends CodeParameterItem
+      ? TGroup['items'][Key]['value']
+      : unknown;
+};
+
+/**
+ * Code Parameters Builder
+ */
+export class CodeParametersBuilder<TGroup extends CodeParameterGroup> {
+  /**
+   * Built suggestions based on config
+   *
+   * @type {CodeEditorSuggestionItem[]}
+   */
+  suggestions: CodeEditorSuggestionItem[] = [];
+
+  constructor(group: TGroup, basePath = 'context') {
+    this.suggestions.push({
+      label: basePath,
+      kind: CodeEditorSuggestionItemKind.Constant,
+      detail: group.detail,
+    });
+    this.addSuggestions(basePath, group);
+  }
+
+  /**
+   * Add suggestions
+   */
+  private addSuggestions(path: string, group: CodeParameterGroup): void {
+    Object.entries(group.items).forEach(([key, value]) => {
+      const itemPath = `${path}.${key}`;
+
+      if ('items' in value) {
+        this.suggestions.push({
+          label: itemPath,
+          detail: value.detail,
+          kind: CodeEditorSuggestionItemKind.Property,
+        });
+        this.addSuggestions(itemPath, value);
+        return;
+      }
+
+      this.suggestions.push({
+        label: itemPath,
+        detail: value.detail,
+        kind: value.kind,
+      });
+    });
+  }
+
+  /**
+   * Create payload method for type validation
+   */
+  create(payload: PayloadForGroup<TGroup>): PayloadForGroup<TGroup> {
+    return payload;
+  }
+}

--- a/src/utils/code-parameters.ts
+++ b/src/utils/code-parameters.ts
@@ -11,10 +11,10 @@ import {
 import { LocationService } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import { CodeEditorSuggestionItemKind } from '@grafana/ui';
-import { CodeParameterItem, CodeParametersBuilder } from '@volkovlabs/components';
 import handlebars from 'handlebars';
-// eslint-disable-next-line @typescript-eslint/naming-convention
 import MarkdownIt from 'markdown-it';
+
+import { CodeParameterItem, CodeParametersBuilder } from './code-parameters-builder';
 
 /**
  * Render Code Parameters


### PR DESCRIPTION
## Summary

- Inlines `AutosizeCodeEditor`, `Toolbar`, and `CodeParametersBuilder` from `@volkovlabs/components` into `src/`
- Adds comprehensive unit tests for `AutosizeCodeEditor` (21 tests) and `Toolbar` (25 tests)
- Updates all imports from `@volkovlabs/components` to local modules
- Removes the `@volkovlabs/components` dependency entirely
- Bundle size reduced from 1.91 MiB to 1.36 MiB

## Stacked PR

This is **PR 2 of 2**, targeting `briangann/update_infra` (#34).
Together, these two PRs replicate the full scope of #30.

## Test plan

- [x] `npm run build` succeeds (1.36 MiB bundle)
- [x] `npm run lint` passes (warnings only)
- [x] `npm run test:ci` — 19 suites, 191 tests pass
- [x] `git diff origin/briangann/update_all` (excluding lockfile) — only expected `react-router-dom` externals line