### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed typos in `test/utils/text.ts`, `README.md`, and documentation URLs.
 - Fixed markdown lint issues in `README.md` and `CHANGELOG.md`.
 
+### Project Updates
+
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+
 ## [6.2.0] - 2025-10-28
 
 ### Project Updates


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are
a common supply-chain attack vector.

## What changed

- Added `.npmrc` with `ignore-scripts=true`

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts, so existing installs are
unaffected.

## References

- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)

## Test plan

- [ ] `npm install` completes successfully with `.npmrc` in place