### PR TITLE
ci: migrate publish workflow to changelog validation, bump vitest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Coverage report
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-path: coverage/coverage-summary.json
           json-summary-compare-path: ${{ steps.base-coverage.outputs.exists == 'true' && '/tmp/base-coverage/coverage-summary.json' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,52 +23,52 @@ on:
 permissions: {}
 
 jobs:
-  stamp-changelog:
-    name: Stamp changelog
+  check-changelog:
+    name: Check changelog
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
-        with:
-          github_app: grafana-plugins-platform-bot
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Replace [Unreleased] with version and date
+      - name: Verify CHANGELOG.md files have no [Unreleased] section
         run: |
-          grep -q "## \[Unreleased\]" CHANGELOG.md || { echo "No [Unreleased] heading in CHANGELOG.md \ already stamped?"; exit 1; }
-          VERSION=$(node -p "require('./package.json').version")
-          DATE=$(date -u +%Y-%m-%d)
-          sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" CHANGELOG.md
+          check_changelog() {
+            local file="$1"
+            UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" "$file" | head -1 | cut -d: -f1)
+            RELEASE_LINE=$(grep -n "^## \[[0-9]" "$file" | head -1 | cut -d: -f1)
+
+            # No [Unreleased] section — nothing to check
+            if [ -z "$UNRELEASED_LINE" ]; then
+              return 0
+            fi
+
+            # [Unreleased] is below the latest release — fine
+            if [ -n "$RELEASE_LINE" ] && [ "$UNRELEASED_LINE" -gt "$RELEASE_LINE" ]; then
+              return 0
+            fi
+
+            VERSION=$(jq -r '.version' package.json)
+            echo "Error: $file contains an [Unreleased] section."
+            echo "A released version is required and must match package.json (${VERSION})."
+            return 1
+          }
+
+          check_changelog CHANGELOG.md || exit 1
           if [ -f src/CHANGELOG.md ]; then
-            grep -q "## \[Unreleased\]" src/CHANGELOG.md || { echo "No [Unreleased] heading in src/CHANGELOG.md \ already stamped?"; exit 1; }
-            sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" src/CHANGELOG.md
+            check_changelog src/CHANGELOG.md || exit 1
           fi
-      - name: Commit changelog stamp
-        env:
-          BRANCH: ${{ github.event.inputs.branch }}
-        run: |
-          git config user.name 'grafana-plugins-platform-bot[bot]'
-          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
-          git add CHANGELOG.md
-          [ -f src/CHANGELOG.md ] && git add src/CHANGELOG.md
-          git diff --staged --quiet || git commit -m "chore: stamp changelog for release"
-          git push origin HEAD:$BRANCH
 
   cd:
     name: CD
-    needs: stamp-changelog
+    needs: check-changelog
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
-      contents: write
-      pull-requests: read
-      id-token: write
       attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.
 ### Project Updates
 
 - Removed `pr-files.yml` workflow; GitHub's native Files changed tab supersedes it.
-
-### Project Updates
-
 - Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+- Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation.
+- Bumped `vitest-coverage-report-action` to v2.12.0.
 
 ## [6.2.0] - 2025-10-28
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.2.3] - 2026-05-21
 
 ### Build / Tooling
 
 - Added `playwright-report/**` to cspell `ignorePaths` and ESLint `ignores` to exclude generated test artifacts.
-- `publish.yml`: bump `actions/create-github-app-token` to v3.1.1; stamp and `git add` `src/CHANGELOG.md`
-  conditionally on release.
+- `publish.yml`: replace `stamp-changelog` with `check-changelog` (read-only pre-flight validation);
+  validates both `CHANGELOG.md` and `src/CHANGELOG.md` before release.
 - `coverage.yml`:
   - Add concurrency group.
   - Bump `actions/setup-node` to v6.4.0.
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Re-checkout PR branch and restore both coverage files before reporting.
   - Add conditional compare path (skips comparison when base has no coverage).
   - Switch `file-coverage-mode` to `changes-affected`.
-  - Bump `davelosert/vitest-coverage-report-action` to v2.11.2.
+  - Bump `davelosert/vitest-coverage-report-action` to v2.12.0.
   - Add `coverage-detail` job using `ArtiomTr/jest-coverage-report-action` v2.3.1.
 - `pr-files.yml`:
   - Add concurrency group.


### PR DESCRIPTION
### CI/CD

- `publish.yml`: Simplify the publish workflow — instead of automatically stamping and committing a changelog entry at publish time,
  the workflow now verifies the changelog is already stamped before proceeding. Validates both `CHANGELOG.md` and `src/CHANGELOG.md`
  if present.

### Dependencies

- `coverage.yml`: Bump `vitest-coverage-report-action` to v2.12.0.

## Test plan

- [ ] Trigger publish on a branch with stamped `CHANGELOG.md` and `src/CHANGELOG.md` — workflow passes
- [ ] Trigger publish on a branch with an `[Unreleased]` section in either file — workflow fails with a clear error
- [ ] Confirm the `cd` job runs after the changelog check passes