### PR TITLE
fix: re-apply After Content Ready script cleanly on re-render

### DIFF
--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -136,6 +136,12 @@ export const Row: React.FC<Props> = ({
   useEffect(() => {
     let unsubscribe: unknown = null;
     if (ref.current && afterRender) {
+      /**
+       * Reset to the rendered HTML so the script runs against a clean base on every
+       * re-render (React only re-applies dangerouslySetInnerHTML when item.html changes).
+       */
+      ref.current.innerHTML = item.html;
+
       const func = createExecutionCode('context', afterRender);
 
       unsubscribe = func.call(
@@ -174,6 +180,7 @@ export const Row: React.FC<Props> = ({
     getUserPreference,
     item.data,
     item.dataFrame,
+    item.html,
     item.panelData,
     notifyError,
     notifySuccess,

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -1,4 +1,4 @@
-import { AppEvents, FieldType, toDataFrame } from '@grafana/data';
+import { AppEvents, FieldType, LoadingState, toDataFrame } from '@grafana/data';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -240,6 +240,85 @@ describe('Text', () => {
       await act(async () => rerender(<Text {...props} timeZone="123" />));
 
       expect(eventBus.publish).toHaveBeenCalledWith('destroy');
+    });
+  });
+
+  describe('After Render Function on re-render', () => {
+    const realFrame = () => toDataFrame({ fields: [{ name: 'text', type: FieldType.string, values: ['hello'] }] });
+
+    const baseProps = (frame: any, data: any): Props => ({
+      data,
+      frame,
+      options: {
+        ...DEFAULT_OPTIONS,
+        content: '<div data-testid="content">REAL</div>',
+        defaultContent: '<div data-testid="content">INITIAL</div>',
+        afterRender: `
+          const marker = document.createElement('span');
+          marker.setAttribute('data-testid', 'marker');
+          context.element.appendChild(marker);
+        `,
+        renderMode: RenderMode.EVERY_ROW,
+      } as any,
+      timeRange: {} as any,
+      timeZone: '',
+      replaceVariables: (str: string) => str,
+      eventBus: { publish: jest.fn(), subscribe: jest.fn(), getStream: jest.fn() } as any,
+      getUserPreference: getUserPreferenceDefault,
+      setUserPreference,
+    });
+
+    it('applies the script once when data updates without content change', async () => {
+      const frame1 = realFrame();
+      const { rerender } = await act(async () =>
+        render(<Text {...baseProps(frame1, { state: LoadingState.Done, series: [frame1] })} />)
+      );
+
+      expect(screen.getByText('REAL')).toBeInTheDocument();
+      expect(screen.getAllByTestId('marker')).toHaveLength(1);
+
+      const frame2 = realFrame();
+      await act(async () =>
+        rerender(<Text {...baseProps(frame2, { state: LoadingState.Done, series: [frame2] })} />)
+      );
+
+      expect(screen.getByText('REAL')).toBeInTheDocument();
+      expect(screen.getAllByTestId('marker')).toHaveLength(1);
+    });
+
+    it('keeps content during a loading state', async () => {
+      const frame1 = realFrame();
+      const { rerender } = await act(async () =>
+        render(<Text {...baseProps(frame1, { state: LoadingState.Done, series: [frame1] })} />)
+      );
+      expect(screen.getByText('REAL')).toBeInTheDocument();
+
+      await act(async () =>
+        rerender(<Text {...baseProps(frame1, { state: LoadingState.Loading, series: [frame1] })} />)
+      );
+
+      expect(screen.queryByText('INITIAL')).not.toBeInTheDocument();
+      expect(screen.getByText('REAL')).toBeInTheDocument();
+    });
+
+    it('applies the script once across a loading then done update', async () => {
+      const frame1 = realFrame();
+      const { rerender } = await act(async () =>
+        render(<Text {...baseProps(frame1, { state: LoadingState.Done, series: [frame1] })} />)
+      );
+      expect(screen.getAllByTestId('marker')).toHaveLength(1);
+
+      await act(async () =>
+        rerender(<Text {...baseProps(frame1, { state: LoadingState.Loading, series: [frame1] })} />)
+      );
+
+      const frame2 = realFrame();
+      await act(async () =>
+        rerender(<Text {...baseProps(frame2, { state: LoadingState.Done, series: [frame2] })} />)
+      );
+
+      expect(screen.getByText('REAL')).toBeInTheDocument();
+      expect(screen.getAllByTestId('marker')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## What

The After Content Ready script (`afterRender`) imperatively mutates the panel DOM. On a re-render it could run again on top of its own previous output, so the DOM accumulated or became inconsistent.

## Likely cause

The panel renders base HTML via `dangerouslySetInnerHTML={{ __html: item.html }}` and then mutates it in the After Content Ready `useEffect` (keyed on `item.data` / `item.panelData` / `item.dataFrame`). React only re-applies `dangerouslySetInnerHTML` when `item.html` changes, so when the rendered HTML is unchanged the container is not reset and the script re-runs on top of its prior output.

It surfaces now because the panel receives a fresh `PanelData` on query re-runs even when the data is identical (likely scenes [#1376](https://github.com/grafana/scenes/pull/1376), which makes `SceneQueryRunner` emit when `requestId` changes despite identical data), so the effect re-runs while the HTML stays the same. Not confirmed as the exact release-level change.

## Fix

Reset `ref.current.innerHTML = item.html` before running the script (and track `item.html` in the deps), so it always re-applies once against a clean base.

## Tests

Added `Text.test.tsx` cases for the re-render paths (marker count goes 3 → 1; content preserved during loading). Full suite 194 passing; `tsc` and `eslint` clean. No changelog entry included; happy to add one in the project's format if preferred.
