### PR TITLE
CD: upgrade plugins-platform cd.yml to v10.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
   cd:
     name: CD
     needs: check-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,5 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      attestation: true
       signature-type: community
       run-playwright: false


### PR DESCRIPTION
Publish to catalog is broken: https://github.com/grafana/business-text/actions/runs/28378529525/job/84075104251

Doesn't seem to be any docs on this, but https://raintank-corp.slack.com/archives/C01C4K8DETW/p1782244679897549?thread_ts=1782239399.670649&cid=C01C4K8DETW and copying what logs drilldown did here: https://github.com/grafana/logs-drilldown/pull/1972/changes